### PR TITLE
Release/canada go live

### DIFF
--- a/app/confirmation/page.tsx
+++ b/app/confirmation/page.tsx
@@ -10,16 +10,18 @@ const CONFIRM_MESSAGES: Record<LocaleKey, Record<VariantKey, string>> = {
   en: {
     default:
       'We have received your request. If the information is complete and correct, your account will be activated within 48 hours. For questions or follow-up, please contact us at rs.cancustomermaster@medtronic.com.',
-    resellYes: 'Your request will be assessed; our team will contact you.  For questions, please contact us at rs.cancustomermaster@medtronic.com.',
+    resellYes:
+      'Your request will be assessed; our Distributor Channel Management team will contact you.  For questions, please contact us at rs.cancustomermaster@medtronic.com.',
     lowPurchase:
-      'Based on the information provided, your expected annual purchase is below $50,000. To ensure timely service and appropriate support, we kindly ask you to access Medtronic products through our authorized distribution partners. For questions or follow-up, please contact us at rs.cancustomermaster@medtronic.com.',
+      'We have received your request. If the information is complete and correct, your account will be activated within 48 hours. For questions or follow-up, please contact us at rs.cancustomermaster@medtronic.com.',
   },
   fr: {
     default:
       'Nous avons reçu votre demande. Si les informations sont complètes et exactes, votre compte sera activé dans les 48 heures. Pour toute question ou suivi, veuillez nous contacter à rs.cancustomermaster@medtronic.com.',
-    resellYes: 'Votre demande sera évaluée; notre équipe vous contactera.  Pour toute question ou suivi, veuillez nous contacter à rs.cancustomermaster@medtronic.com.',
+    resellYes:
+      'Votre demande sera évaluée; notre équipe de gestion des canaux de distribution vous contactera.  Pour toute question ou suivi, veuillez nous contacter à rs.cancustomermaster@medtronic.com.',
     lowPurchase:
-      'Selon les informations fournies, votre achat annuel estimé est inférieur à 50 000 $. Pour assurer un service rapide et un soutien approprié, nous vous invitons à accéder aux produits Medtronic par l’intermédiaire de nos partenaires de distribution autorisés.   Pour toute question ou suivi, veuillez nous contacter à rs.cancustomermaster@medtronic.com.',
+      'Nous avons reçu votre demande. Si les informations sont complètes et exactes, votre compte sera activé dans les 48 heures. Pour toute question ou suivi, veuillez nous contacter à rs.cancustomermaster@medtronic.com.',
   },
 };
 

--- a/app/lib/email/htmlBuilder.ts
+++ b/app/lib/email/htmlBuilder.ts
@@ -13,7 +13,7 @@ type BuildEmailOptions = {
 
 const TRADE_FIELDS = ["Company", "Account", "Address", "Tel", "Contact", "Email"] as const;
 const TAX_EXEMPT_INSTRUCTION =
-  "Taxes team approval must be in place to set the customer with a Tax exemption code";
+  ". Taxes team approval must be in place to set the customer with a Tax exemption code.";
 
 function normalizeValue(value: string | undefined): string {
   return (value ?? "").trim().toLowerCase();
@@ -55,9 +55,9 @@ function buildInstructionText(formData: FormDataValues): string {
     instruction = "CUSTOMER CREATION MUST WAIT UNTIL CHANNEL MANAGEMENT APPROVES";
   } else if (isLowAnnualPurchase(annualValue)) {
     instruction =
-      "THIS IS A LOW VOLUME CUSTOMER, SHOULD NOT BE CREATED, CUSTOMER WAS ADVISED TO CONTACT A DISTRIBUTOR";
+      "PROCEED DIRECTLY WITH THE CREATION OF THIS ACCOUNT. ADDITIONALLY, CHANNEL TEAM HAS BEEN INFORMED OF THIS LOW VOLUME CUSTOMER REQUEST ";
   } else {
-    instruction = "PROCEED DIRECTLY WITH THE CREATION OF THIS CUSTOMER";
+    instruction = "PROCEED DIRECTLY WITH THE CREATION OF THIS ACCOUNT";
   }
 
   if (isNo(formData.taxable)) {

--- a/app/lib/emailTargets.ts
+++ b/app/lib/emailTargets.ts
@@ -4,13 +4,11 @@ export const EMAIL_TARGETS = {
   ],
   channelManagement: ["dayna.white@medtronic.com"],
   creditTeam: ["rs.cancredit@medtronic.com"],
-  taxesTeam: ["libia.poveda@medtronic.com"],
+  taxesTeam: ["luis.sergio.martinez@medtronic.com"], 
 } satisfies Record<string, string[]>;
 
 export const RESEND_BCC = [
-  "luis.sergio.martinez@medtronic.com",
   "ricardo.a.morcillo@medtronic.com",
-  "lsmtz10@hotmail.com",
   "lsmtz10@gmail.com",
 ] satisfies string[];
 

--- a/app/locales.ts
+++ b/app/locales.ts
@@ -67,7 +67,7 @@ export const MESSAGES = {
       annualPurchase: { label: "Expected Annual Purchase" },
       taxable: { label: "Taxable" },
       taxExemptionTypes: { label: "Select applicable tax exemption type(s)" },
-      craBusinessNumber: { label: "CRA Business Number or GST/HST/PST number" },
+      craBusinessNumber: { label: "CRA Business Number or GST/HST/PST/QST number" },
       taxExemptFile: {
         label: "Tax Exemption supporting  document (PDF, max 3 MB)",
         selectFile: "Click here to select file",
@@ -155,6 +155,7 @@ export const MESSAGES = {
         gst: "GST",
         hst: "HST",
         pst: "PST",
+        qst: "QST",
       },
 
       // NOT IN PDF: province dropdown is not in the PDF (PDF just says "Province:")
@@ -252,7 +253,7 @@ export const MESSAGES = {
       tradeRefAccountRequired: "Trade Ref {idx} Account No. is required.",
       tradeRefContactRequired: "Trade Ref {idx} Contact Person is required.",
       intendedDistributionRequired: "Select at least one distribution option.",
-      taxExemptionTypesRequired: "Select 1 or more options: GST, HST, PST.",
+      taxExemptionTypesRequired: "Select 1 or more options: GST, HST, PST, QST.",
       taxExemptFileRequired: "Tax exempt certificate PDF is required.",
       taxExemptFileType: "File must be a PDF.",
       taxExemptFileSize: "File must be 3 MB or less.",
@@ -350,7 +351,7 @@ export const MESSAGES = {
       annualPurchase: { label: "Estimée d’achats annuels" },
       taxable: { label: "Taxable" },
       taxExemptionTypes: { label: "Sélectionnez le(s) type(s) de taxe applicable(s)" },
-      craBusinessNumber: { label: "Numéro d'entreprise ARC ou numéro TPS/TVH/TVP" },
+      craBusinessNumber: { label: "Numéro d'entreprise ARC ou numéro TPS/TVH/TVP/TVQ" },
       taxExemptFile: {
         label: "Certificat d'exemption (PDF, 3 MB max)",
         selectFile: "Cliquez ici pour sélectionner un fichier",
@@ -438,6 +439,7 @@ export const MESSAGES = {
         gst: "GST",
         hst: "HST",
         pst: "PST",
+        qst: "QST",
       },
 
       // NOT IN PDF: province dropdown is not in the PDF (PDF just says "Province:")
@@ -534,7 +536,7 @@ export const MESSAGES = {
       tradeRefAccountRequired: "Référence commerciale {idx} : No. de compte est requis.",
       tradeRefContactRequired: "Référence commerciale {idx} : Nom du contact est requis.",
       intendedDistributionRequired: "Sélectionnez au moins une option de distribution.",
-      taxExemptionTypesRequired: "Sélectionnez au moins 1 option : GST, HST, PST.",
+      taxExemptionTypesRequired: "Sélectionnez au moins 1 option : GST, HST, PST, QST.",
       taxExemptFileRequired: "Le certificat d'exemption (PDF) est requis.",
       taxExemptFileType: "Le fichier doit etre un PDF.",
       taxExemptFileSize: "Le fichier doit faire 3 MB ou moins.",

--- a/app/locales.ts
+++ b/app/locales.ts
@@ -436,10 +436,10 @@ export const MESSAGES = {
         { value: "no", label: "Non" },
       ],
       taxExemptionTypes: {
-        gst: "GST",
-        hst: "HST",
-        pst: "PST",
-        qst: "QST",
+        gst: "TPS (GST)",
+        hst: "TVH (HST)",
+        pst: "TVP (PST)",
+        qst: "TVQ (QST)",
       },
 
       // NOT IN PDF: province dropdown is not in the PDF (PDF just says "Province:")

--- a/app/page.tsx
+++ b/app/page.tsx
@@ -1349,6 +1349,7 @@ try {
     { value: "GST", label: options.taxExemptionTypes.gst },
     { value: "HST", label: options.taxExemptionTypes.hst },
     { value: "PST", label: options.taxExemptionTypes.pst },
+    { value: "QST", label: options.taxExemptionTypes.qst },
   ];
   const pdfFilename = locale === 'fr'
     ? "Credit Application Form - Fr version - Jan25.pdf"
@@ -2036,7 +2037,7 @@ try {
           aria-describedby="taxExemptionTypes-error"
         >
           <legend className="px-1 text-sm font-medium">{fields.taxExemptionTypes.label}</legend>
-          <div className="grid grid-cols-1 sm:grid-cols-3 gap-2 mt-1">
+          <div className="grid grid-cols-1 gap-2 mt-1">
             {taxExemptionTypeOptions.map(opt => {
               const checked = taxExemptionTypes.includes(opt.value);
               return (


### PR DESCRIPTION
- Se añadió la opción `QST` en “Select applicable tax exemption type(s)”.
- Se actualizó la etiqueta a `CRA Business Number or GST/HST/PST/QST number`.
- Se ajustaron los textos de validación de esa sección para incluir `QST` (inglés y francés), y la etiqueta equivalente en francés quedó con `TVQ`.
- En `CONFIRM_MESSAGES` de la página de confirmación:
  - `resellYes` pasó a mencionar al equipo de `Distributor Channel Management` (y equivalente en francés).
  - `lowPurchase` se cambió para usar el mismo texto que `default` (en inglés y francés).
- En la UI de tax exemption, los checkboxes se cambiaron para mostrarse 1 por renglón.
- Solo en francés, las etiquetas visibles de opciones de impuesto quedaron como:
  - `TPS (GST)`
  - `TVH (HST)`
  - `TVP (PST)`
  - `TVQ (QST)`